### PR TITLE
Add apidoc_separate_modules option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,7 @@ documentation's ``conf.py`` file, like so:
     apidoc_module_dir = '../my_code'
     apidoc_output_dir = 'reference'
     apidoc_excluded_paths = ['tests']
+    apidoc_separate_modules = True
 
 Configuration
 -------------
@@ -61,6 +62,12 @@ The *apidoc* extension uses the following configuration values:
    ``apidoc_module_dir``. fnmatch-style wildcarding is supported.
 
    **Optional**, defaults to ``[]``.
+
+``apidoc_separate_modules``
+   Put documentation for each module on its own page. Otherwise there will be
+   one page per (sub)package.
+
+   **Optional**, defaults to ``False``.
 
 Links
 -----

--- a/sphinxcontrib/apidoc/__init__.py
+++ b/sphinxcontrib/apidoc/__init__.py
@@ -28,5 +28,6 @@ def setup(app):
     app.add_config_value('apidoc_module_dir', None, 'env', [str])
     app.add_config_value('apidoc_output_dir', 'api', 'env', [str])
     app.add_config_value('apidoc_excluded_paths', [], 'env', [[str]])
+    app.add_config_value('apidoc_separate_modules', False, 'env', [bool])
 
     return {'version': __version__, 'parallel_read_safe': True}

--- a/tests/roots/test-advanced/apidoc_dummy_module.py
+++ b/tests/roots/test-advanced/apidoc_dummy_module.py
@@ -1,0 +1,12 @@
+from os import *  # noqa
+
+from apidoc_dummy_package import apidoc_dummy_submodule_a as a  # noqa
+from apidoc_dummy_package import apidoc_dummy_submodule_b as b  # noqa
+
+
+class Foo:
+    def __init__(self):
+        pass
+
+    def bar(self):
+        pass

--- a/tests/roots/test-advanced/apidoc_dummy_package/apidoc_dummy_submodule_a.py
+++ b/tests/roots/test-advanced/apidoc_dummy_package/apidoc_dummy_submodule_a.py
@@ -1,0 +1,6 @@
+from __future__ import print_function
+
+
+class Bar(object):
+    def foo(self):
+        print('Hello, world')

--- a/tests/roots/test-advanced/apidoc_dummy_package/apidoc_dummy_submodule_b.py
+++ b/tests/roots/test-advanced/apidoc_dummy_package/apidoc_dummy_submodule_b.py
@@ -1,0 +1,3 @@
+class Baz(object):
+    def inga(self):
+        return 1 + 3

--- a/tests/roots/test-advanced/conf.py
+++ b/tests/roots/test-advanced/conf.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('./'))
+
+extensions = ['sphinxcontrib.apidoc']
+master_doc = 'index'
+
+apidoc_module_dir = '.'
+apidoc_excluded_paths = ['conf.py']
+apidoc_separate_modules = True

--- a/tests/roots/test-advanced/index.rst
+++ b/tests/roots/test-advanced/index.rst
@@ -1,0 +1,6 @@
+apidoc
+======
+
+.. toctree::
+
+   api/modules

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -24,6 +24,23 @@ def test_basics(app, status, warning):
     assert not warning.getvalue()
 
 
+@pytest.mark.sphinx('html', testroot='advanced')
+def test_advanced(app, status, warning):
+    logging.setup(app, status, warning)
+    app.builder.build_all()
+    assert (app.outdir / 'api').isdir()
+    assert (app.outdir / 'api' / 'modules.html').exists()
+    for module in [
+            'apidoc_dummy_module.html',
+            'apidoc_dummy_package.apidoc_dummy_submodule_a.html',
+            'apidoc_dummy_package.apidoc_dummy_submodule_b.html'
+    ]:
+        assert (app.outdir / 'api' / module).exists()
+    assert (app.outdir / 'api' / 'apidoc_dummy_package.html').exists()
+    assert not (app.outdir / 'api' / 'conf.html').exists()
+    assert not warning.getvalue()
+
+
 @pytest.mark.sphinx('html', testroot='missing-configuration')
 def test_missing_configuration(app, status, warning):
     logging.setup(app, status, warning)


### PR DESCRIPTION
Give users the option to have apidoc generate a page-per-module instead
of a page-per-package.