### PR TITLE
tests: Override 'sphinx_test_tempdir'

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@
 """
 
 import os
+import tempfile
 
 import pytest
 from sphinx.testing.path import path
@@ -14,6 +15,14 @@ from sphinx.testing.path import path
 pytest_plugins = 'sphinx.testing.fixtures'
 
 collect_ignore = ['roots']
+
+
+@pytest.fixture(scope='session')
+def sphinx_test_tempdir():
+    return path(
+        os.environ.get(
+            'SPHINX_TEST_TEMPDIR',
+            tempfile.mkdtemp(prefix='apidoc-'))).abspath()
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
The default implementation this places everything in the system's temp
directory (generally '/tmp') without any hierarchy. This means we can be
left with remnants of previous tests which can give false positives.
Resolve this by placing everything inside its own folder. We can fix
this upstream separately.

Signed-off-by: Stephen Finucane <stephen@that.guru>