### PR TITLE
Force overwriting of files with sphinx <1.7

### DIFF
--- a/sphinxcontrib/apidoc/ext.py
+++ b/sphinxcontrib/apidoc/ext.py
@@ -14,8 +14,10 @@ from sphinx.util import logging
 
 try:
     from sphinx.ext import apidoc  # Sphinx >= 1.7
+    _ignore_first_arg = False
 except ImportError:
     from sphinx import apidoc  # Sphinx < 1.7
+    _ignore_first_arg = True
 
 if False:
     # For type annotation
@@ -49,6 +51,9 @@ def builder_inited(app):
     # person - at present there is way too much passing around of the
     # 'optparse.Value' instance returned by 'optparse.parse_args'
     def cmd_opts():
+        if _ignore_first_arg:
+            yield 'sphinxcontrib-apidoc'
+
         yield '--force'
 
         if separate_modules:


### PR DESCRIPTION
Calling sphinx.ext.apidoc.main (which was added in Sphinx 1.7) uses all
of the arguments passed. However, calling sphinx.apidoc.main discards
the first argument (except in 1.7.0). Pass an extra argument in that
case to ensure that the --force option is not ignored.