### PR TITLE
fix the dist name used to get the version after installation

### DIFF
--- a/sphinxcontrib/apidoc/__init__.py
+++ b/sphinxcontrib/apidoc/__init__.py
@@ -12,7 +12,7 @@ import pbr.version
 
 from sphinxcontrib.apidoc import ext
 
-__version__ = pbr.version.VersionInfo('apidoc').version_string()
+__version__ = pbr.version.VersionInfo('sphinxcontrib-apidoc').version_string()
 
 if False:
     # For type annotation


### PR DESCRIPTION
Use the correct dist name so that when we are trying to find the version
of the installed package we can.

Closes #8

Signed-off-by: Doug Hellmann <doug@doughellmann.com>