### PR TITLE
Added support for autodoc --templatedir option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,10 +59,10 @@ The *apidoc* extension uses the following configuration values:
    **Optional**, defaults to ``api``.
 
 ``apidoc_template_dir``
-   A directory containing user-defined templates. Template files in this 
-   directory that match the default apidoc templates (``module.rst_t``, 
+   A directory containing user-defined templates. Template files in this
+   directory that match the default apidoc templates (``module.rst_t``,
    ``package.rst_t``, ``toc.rst_t``) will overwrite them. The default templates
-   can be found in ``site-packages/sphinx/templates/apidoc/``. This path is 
+   can be found in ``site-packages/sphinx/templates/apidoc/``. This path is
    relative to the documentation source directory.
 
    **Optional**, defaults to ``templates``.

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ The *apidoc* extension uses the following configuration values:
    can be found in ``site-packages/sphinx/templates/apidoc/``. This path is
    relative to the documentation source directory.
 
-   **Optional**, defaults to ``templates``.
+   **Optional**, defaults to ``'templates'``.
 
 ``apidoc_excluded_paths``
    An optional list of modules to exclude. These should be paths relative to

--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,15 @@ The *apidoc* extension uses the following configuration values:
 
    **Optional**, defaults to ``api``.
 
+``apidoc_template_dir``
+   A directory containing user-defined templates. Template files in this 
+   directory that match the default apidoc templates (``module.rst_t``, 
+   ``package.rst_t``, ``toc.rst_t``) will overwrite them. The default templates
+   can be found in ``site-packages/sphinx/templates/apidoc/``. This path is 
+   relative to the documentation source directory.
+
+   **Optional**, defaults to ``templates``.
+
 ``apidoc_excluded_paths``
    An optional list of modules to exclude. These should be paths relative to
    ``apidoc_module_dir``. fnmatch-style wildcarding is supported.

--- a/sphinxcontrib/apidoc/__init__.py
+++ b/sphinxcontrib/apidoc/__init__.py
@@ -23,6 +23,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.connect('builder-inited', ext.builder_inited)
     app.add_config_value('apidoc_module_dir', None, 'env', [str])
     app.add_config_value('apidoc_output_dir', 'api', 'env', [str])
+    app.add_config_value('apidoc_template_dir', 'templates', 'env', [str])
     app.add_config_value('apidoc_excluded_paths', [], 'env', [[str]])
     app.add_config_value('apidoc_separate_modules', False, 'env', [bool])
     app.add_config_value('apidoc_toc_file', None, 'env', [str, bool])

--- a/sphinxcontrib/apidoc/ext.py
+++ b/sphinxcontrib/apidoc/ext.py
@@ -64,6 +64,9 @@ def builder_inited(app: Sphinx) -> None:
 
         yield '--output-dir'
         yield output_dir
+        
+        yield '--templatedir'
+        yield template_dir
 
         for arg in extra_args:
             yield arg

--- a/sphinxcontrib/apidoc/ext.py
+++ b/sphinxcontrib/apidoc/ext.py
@@ -65,7 +65,7 @@ def builder_inited(app: Sphinx) -> None:
 
         yield '--output-dir'
         yield output_dir
-        
+
         yield '--templatedir'
         yield template_dir
 

--- a/sphinxcontrib/apidoc/ext.py
+++ b/sphinxcontrib/apidoc/ext.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 def builder_inited(app: Sphinx) -> None:
     module_dir = app.config.apidoc_module_dir
     output_dir = path.join(app.srcdir, app.config.apidoc_output_dir)
+    template_dir = path.join(app.srcdir, app.config.apidoc_template_dir)
     excludes = app.config.apidoc_excluded_paths
     separate_modules = app.config.apidoc_separate_modules
     toc_file = app.config.apidoc_toc_file


### PR DESCRIPTION
Adds handling for setting apidoc_template_dir in conf.py, which passes this variable along with the --templatedir command line option for sphinx-apidoc.

This enables the user to define custom templates, which is supported in sphinx.ext.apidoc but was not previously supported in sphinxcontrib/apidoc.